### PR TITLE
Function circle_mask function fixed in DeepCGH_DPM.py

### DIFF
--- a/DeepCGH_DPM.py
+++ b/DeepCGH_DPM.py
@@ -106,9 +106,9 @@ class DeepCGH_Datasets(object):
         sample1=sample
         star=(self.shape[-1]-1)/2*self.layer
         img1=np.zeros((self.shape[0],self.shape[1]))
-        for k in range(self.shape[-1]):
-            for l in range(self.shape[1]):
-                for m in range(self.shape[-1]):
+        for l in range(self.shape[0]):
+            for m in range(self.shape[1]):
+                for k in range(self.shape[-1]):
                     if sample1[l,m,k]<0.2:
                         sample1[l,m,k]=0
             img1+=sample1[:,:,k] #疊成第一個矩陣

--- a/DeepCGH_DPM.py
+++ b/DeepCGH_DPM.py
@@ -519,8 +519,8 @@ class DeepCGH(object):
             return Gauss
         
         def circle_mask(shape):
-            radius=485
-            #for 20X/0.25 objective
+            NA = 1
+            radius=numpy.arcsin(NA/self.n)*self.f/self.ps
             location=(shape[0]//2+1,shape[1]//2+1)
             img = np.zeros(shape[:-1], dtype=np.float32)
             rr, cc = circle(location[0], location[1], radius, shape=img.shape)

--- a/DeepCGH_DPM.py
+++ b/DeepCGH_DPM.py
@@ -111,7 +111,7 @@ class DeepCGH_Datasets(object):
                 for k in range(self.shape[-1]):
                     if sample1[l,m,k]<0.2:
                         sample1[l,m,k]=0
-            img1+=sample1[:,:,k] #疊成第一個矩陣
+                    img1[l,m]+=sample1[l,m,k] #疊成第一個矩陣
         for i in range(self.shape[0]):
             for j in range(self.shape[1]):
                 for k in range(self.shape[-1]):


### PR DESCRIPTION
Function circle_mask function fixed

I find that the circle_mask function is a whole-one image, so I tried to comprehend this in further, and I find that the radius is 485 only when shape is 1024 (in matters in self.ps), so I amended it by parameterize it, now it will be right in any shape size