### PR TITLE
Fixed comment error in _ifft_amph DeepCGH_DPM.py

### DIFF
--- a/DeepCGH_DPM.py
+++ b/DeepCGH_DPM.py
@@ -570,7 +570,7 @@ class DeepCGH(object):
         
         def __ifft_AmPh(x):
             '''
-            Input is Amp x[1] and Phase x[0]. Spits out the angle of ifft.
+            Input is Amp x[0] and Phase x[1]. Spits out the angle of ifft.
             '''
             shapes=x[2]
             img = tf.dtypes.complex(tf.squeeze(x[0], axis=-1), 0.) * tf.math.exp(tf.dtypes.complex(0., tf.squeeze(x[1], axis=-1)))


### PR DESCRIPTION
The comment is derived from the DeepCGH paper, the error is already existed since then, since that project seems no maintain there. So I make the pr here instead.